### PR TITLE
fix(ci): fix release-please action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Release
     outputs:
-      release_created: ${{ steps.release.outputs.releases_created }}
+      release_created: ${{ steps.release.outputs.release_created }}
     permissions:
       contents: write
       pull-requests: write
@@ -29,8 +29,6 @@ jobs:
     steps:
       - uses: google-github-actions/release-please-action@v4
         id: release
-        with:
-          command: manifest
 
   publish_provider:
     if: needs.release.outputs.release_created


### PR DESCRIPTION
@runlevel5 we need one more PR to go through before a release can be cut. release-please was updated and needed a different configuration; hence, the pipeline failed to create a correct release PR.