### PR TITLE
fix(ci): fix nodejs release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,9 +154,6 @@ jobs:
           packages-dir: "${{ github.workspace }}/sdk/python/bin/dist/"
         if: matrix.language == 'python'
 
-      - name: Copy Over NodeJS Scripts
-        run: cp -rf ${{ github.workspace }}/sdk/nodejs/scripts ${{ github.workspace }}/sdk/nodejs/bin/
-        if: matrix.language == 'nodejs'
       - name: Publish NodeJS SDK
         uses: JS-DevTools/npm-publish@v3
         with:


### PR DESCRIPTION
@runlevel5 sorry for that - we need to go through the release process again with this CI fix included...
the old version was pretty old as you know, and in the meantime Pulumi made a significant change for the NodeJS SDK which i missed after such a huge bump in dependencies..