### PR TITLE
chore: update go version to 1.24.x

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        go-version: [1.21.x]
+        go-version: [1.24.x]
         golangci-lint-version: [v2.5.0]
 
     steps:
@@ -72,7 +72,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        go-version: [1.21.x]
+        go-version: [1.24.x]
         node-version: [22.x]
         dotnet-version: [3.1.301]
         python-version: [3.9]


### PR DESCRIPTION
## Description

The build for the SDK is failing due to an old version of Go being used for building.

This change should allow CI to work.

## Changes

- adjusts the Go version in the `verify` workflow so that it targets the required version of Go (=> v1.24.7)
